### PR TITLE
Proof of concept for being able to test correct loading of config values from file

### DIFF
--- a/tests/0.1.3/.prefab.integration.config.yaml
+++ b/tests/0.1.3/.prefab.integration.config.yaml
@@ -1,0 +1,5 @@
+integration:
+  int: 123
+  float: 5.22
+  bool: true
+  string: "hello"

--- a/tests/0.1.3/tests/enabled.yaml
+++ b/tests/0.1.3/tests/enabled.yaml
@@ -1,0 +1,253 @@
+---
+version: 0.1.3
+function: enabled
+tests:
+
+  ################
+  ## ALWAYS_ON ##
+  ################
+
+  - name: returns the correct value for a simple flag
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.simple"
+    expected:
+      value: true
+
+  - name: returns the correct value for a simple disabled flag
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.simple-disabled"
+    expected:
+      value: false
+
+  - name: always returns false for a non-boolean flag
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.integer"
+    expected:
+      value: false
+
+  ####################
+  ## LOOKUP_KEY_IN ##
+  ####################
+
+  - name: returns true for a LOOKUP_KEY_IN rule when the lookup key matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.lookup-key.positive"
+      lookup_key: "user:1"
+    expected:
+      value: true
+
+  - name: returns false for a LOOKUP_KEY_IN rule when the lookup key doesn't match
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.lookup-key.positive"
+      lookup_key: "user:3"
+    expected:
+      value: false
+
+  ########################
+  ## LOOKUP_KEY_NOT_IN ##
+  ########################
+
+  - name: returns false for a LOOKUP_KEY_NOT_IN rule when the lookup key matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.lookup-key.negative"
+      lookup_key: "user:1"
+    expected:
+      value: false
+
+  - name: returns true for a LOOKUP_KEY_NOT_IN rule when the lookup key doesn't match
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.lookup-key.negative"
+      lookup_key: "user:3"
+    expected:
+      value: true
+
+  #####################
+  ## PROP_IS_ONE_OF ##
+  #####################
+
+  - name: returns true for a PROP_IS_ONE_OF rule when any prop matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.properties"
+      properties:
+        name: "michael"
+        domain: "something.com"
+    expected:
+      value: true
+
+  - name: returns false for a PROP_IS_ONE_OF rule when no prop matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.properties"
+      properties:
+        name: "lauren"
+        domain: "something.com"
+    expected:
+      value: false
+
+  #########################
+  ## PROP_IS_NOT_ONE_OF ##
+  #########################
+
+  - name: returns true for a PROP_IS_NOT_ONE_OF rule when any prop doesn't match
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.properties.negative"
+      properties:
+        name: "lauren"
+        domain: "prefab.cloud"
+    expected:
+      value: true
+
+  - name: returns false for a PROP_IS_NOT_ONE_OF rule when all props match
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.properties.negative"
+      properties:
+        name: "michael"
+        domain: "prefab.cloud"
+    expected:
+      value: false
+
+  ############################
+  ## PROP_ENDS_WITH_ONE_OF ##
+  ############################
+
+  - name: returns true for PROP_ENDS_WITH_ONE_OF rule when the given prop has a matching suffix
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.ends-with-one-of.positive"
+      properties:
+        email: "jeff@prefab.cloud"
+    expected:
+      value: true
+
+  - name: returns false for PROP_ENDS_WITH_ONE_OF rule when the given prop doesn't have a matching suffix
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.ends-with-one-of.positive"
+      properties:
+        email: "jeff@test.com"
+    expected:
+      value: false
+
+  #####################################
+  ## PROP_DOES_NOT_END_WITH_ONE_OF ##
+  #####################################
+
+  - name: returns true for PROP_DOES_NOT_END_WITH_ONE_OF rule when the given prop doesn't have a matching suffix
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.ends-with-one-of.negative"
+      properties:
+        email: "michael@test.com"
+    expected:
+      value: true
+
+  - name: returns false for PROP_DOES_NOT_END_WITH_ONE_OF rule when the given prop has a matching suffix
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.ends-with-one-of.negative"
+      properties:
+        email: "michael@prefab.cloud"
+    expected:
+      value: false
+
+  #############
+  ## IN_SEG ##
+  #############
+
+  - name: returns true for IN_SEG when the segment rule matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.in-segment.positive"
+      lookup_key: "lauren"
+    expected:
+      value: true
+
+  - name: returns false for IN_SEG when the segment rule doesn't match
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.in-segment.positive"
+      lookup_key: "josh"
+    expected:
+      value: false
+
+  - name: returns true for IN_SEG if any segment rule matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.in-segment.multiple-criteria"
+      lookup_key: "josh"
+      properties:
+        domain: "prefab.cloud"
+    expected:
+      value: true
+
+  #################
+  ## NOT_IN_SEG ##
+  #################
+
+  - name: returns true for NOT_IN_SEG when the segment rule doesn't match
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.in-segment.negative"
+      lookup_key: "josh"
+    expected:
+      value: true
+
+  - name: returns false for NOT_IN_SEG when the segment rule matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.in-segment.negative"
+      lookup_key: "michael"
+    expected:
+      value: false
+
+  - name: returns false for NOT_IN_SEG if any segment rule matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.in-segment.multiple-criteria.negative"
+      lookup_key: "josh"
+      properties:
+        domain: "prefab.cloud"
+    expected:
+      value: false
+
+  - name: returns true for NOT_IN_SEG if no segment rule matches
+    client: feature_flag_client
+    function: enabled
+    input:
+      flag: "feature-flag.in-segment.multiple-criteria.negative"
+      lookup_key: "josh"
+      properties:
+        domain: "something.com"
+    expected:
+      value: true

--- a/tests/0.1.3/tests/get.yaml
+++ b/tests/0.1.3/tests/get.yaml
@@ -1,0 +1,49 @@
+---
+version: 0.1.3
+function: get
+tests:
+  - name: get returns a found value for key
+    client: config_client
+    function: get
+    input:
+      key: "my-test-key"
+    expected:
+      value: "my-test-value"
+
+  - name: get returns nil if value not found
+    client: config_client
+    function: get
+    input:
+      key: "my-missing-key"
+    expected:
+      value: ~
+    client_overrides:
+      on_no_default: 2
+
+  - name: get returns a default for a missing value if a default is given
+    client: config_client
+    function: get
+    input:
+      key: "my-missing-key"
+      default: "DEFAULT"
+    expected:
+      value: "DEFAULT"
+
+  - name: get ignores a provided default if the key is found
+    client: config_client
+    function: get
+    input:
+      key: "my-test-key"
+      default: "DEFAULT"
+    expected:
+      value: "my-test-value"
+
+  - name: get respects a provided namespace when initializing the client
+    client: config_client
+    function: get
+    input:
+      key: "my-test-key"
+    expected:
+      value: "my-namespaced-value"
+    client_overrides:
+      namespace: "test-namespace"

--- a/tests/0.1.3/tests/get_feature_flag.yaml
+++ b/tests/0.1.3/tests/get_feature_flag.yaml
@@ -1,0 +1,20 @@
+---
+version: 0.1.3
+function: get_feature_flag
+tests:
+  - name: get returns the underlying value for a feature flag
+    client: feature_flag_client
+    function: get
+    input:
+      flag: "feature-flag.integer"
+    expected:
+      value: 3
+
+  - name: get returns the underlying value for a feature flag that matches the highest precedent rule
+    client: feature_flag_client
+    function: get
+    input:
+      flag: "feature-flag.integer"
+      lookup_key: "michael"
+    expected:
+      value: 5

--- a/tests/0.1.3/tests/get_local_overrides.yaml
+++ b/tests/0.1.3/tests/get_local_overrides.yaml
@@ -1,0 +1,39 @@
+---
+version: 0.1.3
+function: get
+tests:
+  - name: reads_nested_int
+    client: config_client
+    input:
+      key: "integration.int"
+    expected:
+      value: 123
+    client_overrides:
+      prefab_envs: "integration"
+
+  - name: reads_nested_float
+    client: config_client
+    input:
+      key: "integration.float"
+    expected:
+      value: 5.22
+    client_overrides:
+      prefab_envs: "integration"
+
+  - name: reads_nested_bool
+    client: config_client
+    input:
+      key: "integration.bool"
+    expected:
+      value: true
+    client_overrides:
+      prefab_envs: "integration"
+
+  - name: reads_nested_string
+    client: config_client
+    input:
+      key: "integration.string"
+    expected:
+      value: "hello"
+    client_overrides:
+      prefab_envs: "integration"

--- a/tests/0.1.3/tests/get_or_raise.yaml
+++ b/tests/0.1.3/tests/get_or_raise.yaml
@@ -1,0 +1,23 @@
+---
+version: 0.1.3
+function: get_or_raise
+tests:
+  - name: get_or_raise can raise an error if value not found
+    client: config_client
+    function: get_or_raise
+    input:
+      key: "my-missing-key"
+    expected:
+      status: raise
+      error: missing_default
+      message: "No value found for key 'my-missing-key'"
+
+  - name: get_or_raise returns a default value instead of raising
+    client: config_client
+    function: get_or_raise
+    input:
+      key: "my-missing-key"
+      default: "DEFAULT"
+    expected:
+      value: "DEFAULT"
+


### PR DESCRIPTION
Suggested by @jkebinger, this provides a local config override file and tests to ensure all its values are loaded.

Changes required in integration test harnesses:
1. ensure ability to parse `prefab_envs` from the `client_overrides` map in test data
2. make `path/to/integration/data/tests/current/version` the `prefab_config_classpath_dir` value in the Options you build for running the integration tests
3. when finding test files to load, watch out for the new final `tests/` directory

I think that should be it. I'll build out the proof of concept in the Elixir library to confirm

Important files to note here are `.prefab.integration.config.yaml` and `tests/get_local_overrides.yaml`